### PR TITLE
minor: Switch to Amazon Linux 2023

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ resource "time_static" "this" {}
 resource "aws_lightsail_instance" "this" {
   name              = "vpn-${var.lightsail_region}-${formatdate("YYYYMMDD", "${time_static.this.rfc3339}")}"
   availability_zone = "${var.lightsail_region}${var.lightsail_availability_zone}"
-  blueprint_id      = "amazon_linux_2"
+  blueprint_id      = "amazon_linux_2023"
   bundle_id         = "nano_2_0"
   user_data = templatefile("${path.module}/userdata.sh.tftpl", {
     tailscale_preauth_key = tailscale_tailnet_key.this.key


### PR DESCRIPTION
This PR changes the blueprint_id for the deployment from `amazon_linux_2` to `amazon_linux_2023`.

Amazon Linux 2023 is EoL in 2029.