### PR TITLE
ci: Update release-drafter config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,6 @@
 ---
-name-template: "$RESOLVED_VERSION"
-tag-template: "$RESOLVED_VERSION"
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
 change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
 categories:
   - title: Major Changes


### PR DESCRIPTION
This PR updates the release-drafter config to prefix draft releases with `v`.