### PR TITLE
minor: Update naming pattern for instances

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,13 +11,13 @@
 resource "time_static" "this" {}
 
 resource "aws_lightsail_instance" "this" {
-  name              = "vpn-${var.lightsail_region}-${formatdate("YYYYMMDD", "${time_static.this.rfc3339}")}"
+  name              = "vpn-${var.lightsail_region}-${formatdate("YYYYMMDDhhmmss", "${time_static.this.rfc3339}")}"
   availability_zone = "${var.lightsail_region}${var.lightsail_availability_zone}"
   blueprint_id      = "amazon_linux_2023"
   bundle_id         = "nano_2_0"
   user_data = templatefile("${path.module}/userdata.sh.tftpl", {
     tailscale_preauth_key = tailscale_tailnet_key.this.key
-    tailscale_hostname    = var.lightsail_region
+    tailscale_hostname    = "${var.lightsail_region}-${formatdate("YYYYMMDDhhmmss", "${time_static.this.rfc3339}")}"
   })
   ip_address_type = "dualstack"
 }


### PR DESCRIPTION
This PR updates the naming scheme to accomplish the following things:

- Lightsail and Tailscale names now match exactly
- When a new Lightsail instance is deployed, the name will be unique in Tailscale preventing a -X increment in the name

Tailscale does not immediately delete ephemeral nodes, so if an instance is redeployed with the same name it becomes `name-1`. This change prevents this behavior.