### PR TITLE
minor: Switch to nano_3_0 bundle

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ resource "aws_lightsail_instance" "this" {
   name              = "vpn-${var.lightsail_region}-${formatdate("YYYYMMDDhhmmss", "${time_static.this.rfc3339}")}"
   availability_zone = "${var.lightsail_region}${var.lightsail_availability_zone}"
   blueprint_id      = "amazon_linux_2023"
-  bundle_id         = "nano_2_0"
+  bundle_id         = "nano_3_0"
   user_data = templatefile("${path.module}/userdata.sh.tftpl", {
     tailscale_preauth_key = tailscale_tailnet_key.this.key
     tailscale_hostname    = "${var.lightsail_region}-${formatdate("YYYYMMDDhhmmss", "${time_static.this.rfc3339}")}"


### PR DESCRIPTION
This PR changes the `bundle_id` to `nano_3_0`.

This change allows 2 vCPU for the same price ($5). `nano_2_0` only permits 1 vCPU for the same price.

```json
{
    "price": 5.0,
    "cpuCount": 2,
    "diskSizeInGb": 20,
    "bundleId": "nano_3_0",
    "instanceType": "nano",
    "isActive": true,
    "name": "Nano",
    "power": 298,
    "ramSizeInGb": 0.5,
    "transferPerMonthInGb": 1024,
    "supportedPlatforms": [
        "LINUX_UNIX"
    ],
    "publicIpv4AddressCount": 1
}
```