### PR TITLE
fix: Remove create_before_destroy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,10 +20,6 @@ resource "aws_lightsail_instance" "this" {
     tailscale_hostname    = "${var.lightsail_region}-${formatdate("YYYYMMDDhhmmss", "${time_static.this.rfc3339}")}"
   })
   ip_address_type = "dualstack"
-
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 resource "aws_lightsail_instance_public_ports" "this" {


### PR DESCRIPTION
This PR removes the create_before_destroy option, as it doesn't really add much advantage to the deployment process. In fact because two instances are running at the same time for a short period, it is arguably "more expensive" to use create_before_destroy.