### PR TITLE
ci: Disable workflow cancellation

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,7 +3,7 @@ name: pull-request
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 on:
   pull_request:


### PR DESCRIPTION
This PR disables cancellation of in-progress runs for pull-request workflows.