### PR TITLE
breaking: Change Tailscale onboarding behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Terraform module for deploying a Tailscale exit node on AWS Lightsail.
 > This module requires a tag defined in Tailscale Access Controls.
 
 > [!WARNING]\
-> This module requires an OAuth client with at least the following scopes: devices:core write, keys:auth-keys write
+> This module requires an OAuth client with at least the following scopes: `devices:core=write`, `keys:auth-keys=write`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Terraform module for deploying a Tailscale exit node on AWS Lightsail.
 
 > [!WARNING]\
-> This module requires a tag defined in Tailscale Access Controls.
-> This module requires an OAuth client with at least the following scopes: devices:core write, keys:auth-keys write
+> - This module requires a tag defined in Tailscale Access Controls.
+> - This module requires an OAuth client with at least the following scopes: devices:core write, keys:auth-keys write
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 Terraform module for deploying a Tailscale exit node on AWS Lightsail.
 
 > [!WARNING]\
-> - This module requires a tag defined in Tailscale Access Controls.
-> - This module requires an OAuth client with at least the following scopes: devices:core write, keys:auth-keys write
+> This module requires a tag defined in Tailscale Access Controls.
+
+> [!WARNING]\
+> This module requires an OAuth client with at least the following scopes: devices:core write, keys:auth-keys write
 
 ## Usage
 

--- a/examples/acl-with-multiple-exit-nodes/README.md
+++ b/examples/acl-with-multiple-exit-nodes/README.md
@@ -1,6 +1,5 @@
 # ACL with multiple exit nodes
 
-This example will deploy multiple Tailscale exit nodes on AWS Lightsail with the following default settings:
-  - `tag:exit` Tailscale tag
+This example will deploy multiple Tailscale exit nodes on AWS Lightsail. The `eu-central-1` deployment uses default settings. The `ap-northeast-1` and `us-east-2` deployments override the default `lightsail_region` and `lightsail_region_friendly_name` settings.
 
 It will also define basic Tailscale access controls and the `tag:exit` tag so they do not need to be manually defined beforehand.

--- a/examples/acl-with-multiple-exit-nodes/acl.json.tftpl
+++ b/examples/acl-with-multiple-exit-nodes/acl.json.tftpl
@@ -11,13 +11,13 @@
     }
   ],
   "tagOwners": {
-    "tag:${tailscale_exit_node_tag_name}": [
+    "${tailscale_exit_node_tag}": [
       "autogroup:admin"
     ]
   },
   "autoApprovers": {
     "exitNode": [
-      "tag:${tailscale_exit_node_tag_name}"
+      "${tailscale_exit_node_tag}"
     ]
   }
 }

--- a/examples/acl-with-multiple-exit-nodes/main.tf
+++ b/examples/acl-with-multiple-exit-nodes/main.tf
@@ -9,15 +9,11 @@ terraform {
       source  = "tailscale/tailscale"
       version = "~> 0.0"
     }
-    time = {
-      source  = "hashicorp/time"
-      version = "~> 0.0"
-    }
   }
 }
 
 provider "aws" {
-  region = "eu-central-1"
+  region = var.lightsail_region
 }
 
 provider "aws" {
@@ -34,12 +30,15 @@ provider "tailscale" {}
 
 resource "tailscale_acl" "this" {
   acl = templatefile("${path.root}/acl.json.tftpl", {
-    tailscale_exit_node_tag_name = "exit"
+    tailscale_exit_node_tag = var.tailscale_exit_node_tag
   })
+  reset_acl_on_destroy = true
 }
 
 module "de_exit_node" {
   source = "github.com/bendwyer/terraform-aws-lightsail-tailscale-exit-node"
+
+  lightsail_instance_name = "vpn-${var.lightsail_region}"
 }
 
 module "jp_exit_node" {
@@ -48,7 +47,9 @@ module "jp_exit_node" {
   providers = {
     aws = aws.jp
   }
-  lightsail_region = "ap-northeast-1"
+  lightsail_instance_name        = "vpn-ap-northeast-1"
+  lightsail_region               = "ap-northeast-1"
+  lightsail_region_friendly_name = "tokyo"
 }
 
 module "us_exit_node" {
@@ -57,5 +58,8 @@ module "us_exit_node" {
   providers = {
     aws = aws.us
   }
-  lightsail_region = "us-east-1"
+
+  lightsail_instance_name        = "vpn-us-east-1"
+  lightsail_region               = "us-east-1"
+  lightsail_region_friendly_name = "ohio"
 }

--- a/examples/acl-with-multiple-exit-nodes/variables.tf
+++ b/examples/acl-with-multiple-exit-nodes/variables.tf
@@ -1,0 +1,11 @@
+variable "lightsail_region" {
+  description = "AWS Lightsail region to deploy to."
+  default     = "eu-central-1"
+  type        = string
+}
+
+variable "tailscale_exit_node_tag" {
+  default     = "tag:exit"
+  description = "Tailscale exit node tag to associate with machine(s). Tag must be be prefixed with 'tag:'"
+  type        = string
+}

--- a/examples/multiple-exit-nodes/README.md
+++ b/examples/multiple-exit-nodes/README.md
@@ -1,7 +1,6 @@
 # Multiple exit nodes
 
-This example will deploy multiple Tailscale exit nodes on AWS Lightsail with the following default settings:
-  - `tag:exit` Tailscale tag
+This example will deploy multiple Tailscale exit nodes on AWS Lightsail. The `eu-central-1` deployment uses default settings. The `ap-northeast-1` and `us-east-2` deployments override the default `lightsail_region` and `lightsail_region_friendly_name` settings.
 
 > [!WARNING]\
 > This example assumes that `tag:exit` is already defined in the Tailscale access controls. See [Defining a tag](https://tailscale.com/kb/1068/acl-tags#defining-a-tag) for more information.

--- a/examples/multiple-exit-nodes/main.tf
+++ b/examples/multiple-exit-nodes/main.tf
@@ -5,19 +5,11 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
-    tailscale = {
-      source  = "tailscale/tailscale"
-      version = "~> 0.0"
-    }
-    time = {
-      source  = "hashicorp/time"
-      version = "~> 0.0"
-    }
   }
 }
 
 provider "aws" {
-  region = "eu-central-1"
+  region = var.lightsail_region
 }
 
 provider "aws" {
@@ -30,18 +22,22 @@ provider "aws" {
   region = "us-east-1"
 }
 
-provider "tailscale" {}
-
 module "de_exit_node" {
   source = "github.com/bendwyer/terraform-aws-lightsail-tailscale-exit-node"
+
+  lightsail_instance_name = "vpn-${var.lightsail_region}"
 }
 
 module "jp_exit_node" {
   source = "github.com/bendwyer/terraform-aws-lightsail-tailscale-exit-node"
+
   providers = {
     aws = aws.jp
   }
-  lightsail_region = "ap-northeast-1"
+
+  lightsail_instance_name        = "vpn-ap-northeast-1"
+  lightsail_region               = "ap-northeast-1"
+  lightsail_region_friendly_name = "tokyo"
 }
 
 module "us_exit_node" {
@@ -50,5 +46,8 @@ module "us_exit_node" {
   providers = {
     aws = aws.us
   }
-  lightsail_region = "us-east-1"
+
+  lightsail_instance_name        = "vpn-us-east-1"
+  lightsail_region               = "us-east-1"
+  lightsail_region_friendly_name = "ohio"
 }

--- a/examples/multiple-exit-nodes/variables.tf
+++ b/examples/multiple-exit-nodes/variables.tf
@@ -1,0 +1,5 @@
+variable "lightsail_region" {
+  description = "AWS Lightsail region to deploy to."
+  default     = "eu-central-1"
+  type        = string
+}

--- a/examples/single-exit-node/README.md
+++ b/examples/single-exit-node/README.md
@@ -1,9 +1,6 @@
 # Single exit node
 
-This example will deploy a single Tailscale exit node on AWS Lightsail with all default settings:
-  - `eu-central-1a` region and availability zone
-  - `tag:exit` Tailscale tag
+This example will deploy a single Tailscale exit node on AWS Lightsail with all default settings.
 
 > [!WARNING]\
-> This example assumes that `tag:exit` is already defined in the Tailscale access controls. See [Defining a tag](https://tailscale.com/kb/1068/acl-tags#defining-a-tag) for more information.
-
+> This example assumes that `tag:exit` is already defined in the Tailscale Access Controls. See [Defining a tag](https://tailscale.com/kb/1068/acl-tags#defining-a-tag) for more information.

--- a/examples/single-exit-node/main.tf
+++ b/examples/single-exit-node/main.tf
@@ -5,23 +5,15 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
-    tailscale = {
-      source  = "tailscale/tailscale"
-      version = "~> 0.0"
-    }
-    time = {
-      source  = "hashicorp/time"
-      version = "~> 0.0"
-    }
   }
 }
 
 provider "aws" {
-  region = "eu-central-1"
+  region = var.lightsail_region
 }
-
-provider "tailscale" {}
 
 module "exit_node" {
   source = "github.com/bendwyer/terraform-aws-lightsail-tailscale-exit-node"
+
+  lightsail_instance_name = "vpn-${var.lightsail_region}"
 }

--- a/examples/single-exit-node/variables.tf
+++ b/examples/single-exit-node/variables.tf
@@ -1,0 +1,5 @@
+variable "lightsail_region" {
+  description = "AWS Lightsail region to deploy to."
+  default     = "eu-central-1"
+  type        = string
+}

--- a/main.tf
+++ b/main.tf
@@ -4,8 +4,8 @@
  * Terraform module for deploying a Tailscale exit node on AWS Lightsail.
  *
  * > [!WARNING]\
- * > This module requires a tag defined in Tailscale Access Controls.
- * > This module requires an OAuth client with at least the following scopes: devices:core write, keys:auth-keys write
+ * > - This module requires a tag defined in Tailscale Access Controls.
+ * > - This module requires an OAuth client with at least the following scopes: devices:core write, keys:auth-keys write
  *
  */
 

--- a/main.tf
+++ b/main.tf
@@ -4,8 +4,10 @@
  * Terraform module for deploying a Tailscale exit node on AWS Lightsail.
  *
  * > [!WARNING]\
- * > - This module requires a tag defined in Tailscale Access Controls.
- * > - This module requires an OAuth client with at least the following scopes: devices:core write, keys:auth-keys write
+ * > This module requires a tag defined in Tailscale Access Controls.
+ *
+ * > [!WARNING]\
+ * > This module requires an OAuth client with at least the following scopes: devices:core write, keys:auth-keys write
  *
  */
 

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@
  * > This module requires a tag defined in Tailscale Access Controls.
  *
  * > [!WARNING]\
- * > This module requires an OAuth client with at least the following scopes: devices:core write, keys:auth-keys write
+ * > This module requires an OAuth client with at least the following scopes: `devices:core=write`, `keys:auth-keys=write`.
  *
  */
 

--- a/main.tf
+++ b/main.tf
@@ -4,22 +4,24 @@
  * Terraform module for deploying a Tailscale exit node on AWS Lightsail.
  *
  * > [!WARNING]\
- * > This module requires a tag defined in Tailscale access controls.
+ * > This module requires a tag defined in Tailscale Access Controls.
+ * > This module requires an OAuth client with at least the following scopes: devices:core write, keys:auth-keys write
  *
  */
 
-resource "time_static" "this" {}
-
 resource "aws_lightsail_instance" "this" {
-  name              = "vpn-${var.lightsail_region}-${formatdate("YYYYMMDDhhmmss", "${time_static.this.rfc3339}")}"
+  name              = var.lightsail_instance_name
   availability_zone = "${var.lightsail_region}${var.lightsail_availability_zone}"
   blueprint_id      = "amazon_linux_2023"
-  bundle_id         = "nano_3_0"
+  bundle_id         = var.lightsail_bundle_id
   user_data = templatefile("${path.module}/userdata.sh.tftpl", {
-    tailscale_preauth_key = tailscale_tailnet_key.this.key
-    tailscale_hostname    = "${var.lightsail_region}-${formatdate("YYYYMMDDhhmmss", "${time_static.this.rfc3339}")}"
+    tailscale_exit_node_tag       = var.tailscale_exit_node_tag
+    tailscale_hostname            = var.tailscale_hostname
+    tailscale_oauth_client_id     = var.tailscale_oauth_client_id
+    tailscale_oauth_client_secret = var.tailscale_oauth_client_secret
   })
   ip_address_type = "dualstack"
+  tags            = var.lightsail_tags
 }
 
 resource "aws_lightsail_instance_public_ports" "this" {
@@ -43,14 +45,4 @@ resource "aws_lightsail_instance_public_ports" "this" {
       aws_lightsail_instance.this
     ]
   }
-}
-
-resource "tailscale_tailnet_key" "this" {
-  description         = "preauth-ephemeral-exit"
-  expiry              = 7776000
-  ephemeral           = true
-  preauthorized       = true
-  recreate_if_invalid = "always"
-  reusable            = true
-  tags                = var.tailscale_exit_node_tag_names
 }

--- a/userdata.sh.tftpl
+++ b/userdata.sh.tftpl
@@ -1,7 +1,13 @@
 #!/bin/bash
+ACCESS_TOKEN=$(curl -Ss -d "client_id=${tailscale_oauth_client_id}" -d "client_secret=${tailscale_oauth_client_secret}" "https://api.tailscale.com/api/v2/oauth/token" | jq -r '.access_token')
+# https://github.com/tailscale/terraform-provider-tailscale/issues/68#issuecomment-1314966145
+curl -SsX GET --url 'https://api.tailscale.com/api/v2/tailnet/-/devices' -u "$ACCESS_TOKEN:" |  jq -r '.devices[] | select(.hostname == "${tailscale_hostname}") | .nodeId' |  while read -r nodeid
+  do
+    curl -SsX DELETE --url "https://api.tailscale.com/api/v2/device/$nodeid" -u "$ACCESS_TOKEN:"
+  done
 curl -fsSL https://tailscale.com/install.sh | sh
 echo 'net.ipv4.ip_forward = 1' | sudo tee -a /etc/sysctl.d/99-tailscale.conf
 echo 'net.ipv6.conf.all.forwarding = 1' | sudo tee -a /etc/sysctl.d/99-tailscale.conf
 sysctl -p /etc/sysctl.d/99-tailscale.conf
-tailscale up --advertise-exit-node --authkey=${tailscale_preauth_key} --hostname=${tailscale_hostname}
+tailscale up --advertise-exit-node --authkey="${tailscale_oauth_client_secret}?ephemeral=true&preauthorized=true" --advertise-tags=${tailscale_exit_node_tag} --hostname=${tailscale_hostname}
 tailscale set --auto-update

--- a/variables.tf
+++ b/variables.tf
@@ -1,19 +1,55 @@
+variable "lightsail_availability_zone" {
+  description = "AWS Lightsail availability zone for AWS Lightsail region."
+  default     = "a"
+  type        = string
+}
+
+variable "lightsail_bundle_id" {
+  description = "AWS Lightsail bundle ID. Determines type of instance to deploy."
+  default     = "nano_3_0"
+  type        = string
+}
+
+variable "lightsail_instance_name" {
+  description = "Display name for instance in Lightsail dashboard."
+  type        = string
+}
 variable "lightsail_region" {
   description = "AWS Lightsail region to deploy to."
   default     = "eu-central-1"
   type        = string
 }
 
-variable "lightsail_availability_zone" {
-  description = "AWS Lightsail availability zone for the AWS Lightsail region."
-  default     = "a"
+variable "lightsail_region_friendly_name" {
+  description = "Friendly name for AWS Lightsail region to deploy to."
+  default     = "frankfurt"
   type        = string
 }
 
-variable "tailscale_exit_node_tag_names" {
-  default = [
-    "tag:exit"
-  ]
-  description = "Tailscale exit node tag names to associate with ephemeral key. Tag names must be be prefixed with 'tag:'"
-  type        = set(string)
+variable "lightsail_tags" {
+  description = "A map of key-value pairs used to create AWS Lightsail instance tags. By default no tags will be created."
+  default     = null
+  type        = map(string)
+}
+
+variable "tailscale_exit_node_tag" {
+  default     = "tag:exit"
+  description = "Tailscale exit node tag to associate with machine(s). Tag must be be prefixed with 'tag:'"
+  type        = string
+}
+
+variable "tailscale_hostname" {
+  description = "Display name for instance in Tailscale dashboard"
+  type        = string
+}
+
+variable "tailscale_oauth_client_id" {
+  description = "Tailscale OAuth client ID."
+  type        = string
+}
+
+variable "tailscale_oauth_client_secret" {
+  description = "Tailscale OAuth client secret."
+  type        = string
+  sensitive   = true
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,17 +1,9 @@
 terraform {
-  required_version = ">=1.1.0"
+  required_version = ">=1.10.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = ">=5.37.0"
-    }
-    tailscale = {
-      source  = "tailscale/tailscale"
-      version = ">=0.13.13"
-    }
-    time = {
-      source  = "hashicorp/time"
-      version = ">=0.10.0"
     }
   }
 }


### PR DESCRIPTION
This PR makes a series of breaking changes.

Previous behavior in Tailscale was to add `-1` to the end of a hostname if that hostname was already registered to a different machine. 

Now the userdata.sh script will make a few API calls to clear the hostname that matches the AWS Lightsail instance that is in the process of onboarding. This requires the use of an OAuth client to make the API calls and complete registration. A tailnet key is no longer required.

Since a tailnet key is no longer required, the `tailscale` provider is no longer required. Additionally the `time` provider is no longer used directly by this module so it has also been removed.

Some flexibility has been added to how instance and hostname names are set. Previously they were a pattern built from different variables, but now they are both single variables that can be independently customized from the calling/root module instead of inside this module.

The `lightsail_bundle_id` has been parameterized, allowing larger instances to be deployed. Use caution, as IPv6-only bundles might not work with `ip_address_type = dualstack`.

Finally terraform-docs examples have been brought up to date.